### PR TITLE
Fix precision recall

### DIFF
--- a/chapter_5/source_code/precision_recall/precision_recall.cpp
+++ b/chapter_5/source_code/precision_recall/precision_recall.cpp
@@ -178,6 +178,7 @@ int main( int argc, const char** argv )
                         if( (surface_overlap > 0.5 * surface_det) && (surface_overlap > 0.5 * surface_anno) && (surface_det < (1.5 * surface_anno)) && (surface_det > (0.5 * surface_anno))){
                              TP++;
                              false_positive = false;
+                             continue; // We do not need to process further, else we risk a chance of a single detection yielding 2 TP's
                         }
                     }
                     // Check if a TP was given, else a FP needs to be added
@@ -204,9 +205,9 @@ int main( int argc, const char** argv )
                         int surface_overlap = x_overlap * y_overlap;
 
                         // Rule to define what to increase - dependend on 50% overlap for a good match AND a max 50% larger detection
-                        if( (surface_overlap > 0.5 * surface_det) && (surface_overlap > 0.5 * surface_anno) ){
-                             TP++;
+                        if( (surface_overlap > 0.5 * surface_det) && (surface_overlap > 0.5 * surface_anno) && (surface_det < (1.5 * surface_anno)) && (surface_det > (0.5 * surface_anno))){
                              no_matches = false;
+                             continue; // We do not need to process further, because we already know there is a match
                         }
                     }
                 }

--- a/chapter_5/source_code/precision_recall/precision_recall.cpp
+++ b/chapter_5/source_code/precision_recall/precision_recall.cpp
@@ -107,7 +107,23 @@ int main( int argc, const char** argv )
 
         // Now convert the data to the needed rectangles
         int amount_rectangles = atoi(line_elements[1].c_str());
-        vector<scored_rect> image_rectangles;
+        // ---------------------------------------------------------------------
+        // Small addition here to OpenCV 3 Blueprints book
+        //   --> if an image did not trigger detections it has a structure
+        //       inside a detection file like "/data/image1.png 0"
+        //   --> however this file will result in an unitialized vector of 
+        //       scored rects, yielding problems later on
+        //   --> a quick and dirty fix is to add a non-meaningfull rectangle
+        //       to make sure we have no unmeaningfull pointers dangling around
+        // ---------------------------------------------------------------------
+        vector<scored_rect> image_rectangles;        
+        if(amount_rectangles == 0){
+            scored_rect single_rectangle;
+            single_rectangle.filename = line_elements[0];
+            single_rectangle.region = Rect(0, 0, 0, 0);
+            single_rectangle.score = 0.0;
+            image_rectangles.push_back(single_rectangle);
+        }
         for(int i = 0; i < amount_rectangles; i ++){
             scored_rect single_rectangle;
             single_rectangle.filename = line_elements[0];


### PR DESCRIPTION
As suggested by @Pessanha24, the precision recall calculation needed some remodelling and fixing.

1. Now the files with 0 detections get a dummy rectangle added but that way all the info is kept and the images are not ignored for triggering false positive detections.

2. Removed double TP counting

3. Fixed early leaving loops for unintentionally wrong counting