### PR TITLE
Fixed undefined Mat objects

### DIFF
--- a/chapter_5/source_code/rotation_invariant_detection/rotation_invariant_object_detection.cpp
+++ b/chapter_5/source_code/rotation_invariant_detection/rotation_invariant_object_detection.cpp
@@ -83,12 +83,13 @@ int main(int argc, char* argv[])
     Mat image = imread(input_image);
     int steps = max_angle / step_angle;
     vector<Mat> rotated_images;
-    // Preprocess the images already, since we will need it for detection purposes
-    cvtColor(rotated, rotated, CV_BGR2GRAY);
-    equalizeHist( rotated, rotated );
+    
     for (int i = 0; i < steps; i ++){
         // Rotate the image
         Mat rotated = image.clone();
+	// Preprocess the images already, since we will need it for detection purposes
+	cvtColor(rotated, rotated, CV_BGR2GRAY);
+	equalizeHist( rotated, rotated );
         rotate(image, (i+1)*step_angle, rotated);
         // Add to the collection of rotated and processed images
         rotated_images.push_back(rotated);


### PR DESCRIPTION
# Description
As described in #32 , the `Mat rotated`  object is preprocessed but the variable is defined later in the for loop. This PR moves the preprocessing to the for loop and avoids preprocessing on undefined Mat objects.

# Fixes
This PR fixes issue #32 

# Environment
- Arch Linux x64
- CLion 2018.6
- OpenCV 3.4.3